### PR TITLE
Fix VDJ_analysis and modify violin plots in 01_qc_filter

### DIFF
--- a/scripts/01_qc_filter.R
+++ b/scripts/01_qc_filter.R
@@ -180,6 +180,7 @@ DATA$CC.Diff <- DATA$S.Score - DATA$G2M.Score
 ### PLOT QC ###
 ###############
 cat("\nPlotting QC metrics ...\n")
+ptsize <- ifelse(ncol(DATA@assays[[opt$assay]]@counts) < 5000, 0.1, 0)  # do not show points if >5k cells
 for(i in as.character(unlist(strsplit(opt$columns_metadata,",")))){
 feats <- colnames(DATA@meta.data) [ grepl("nFeature|nCount|_index|[.]Score",colnames(DATA@meta.data) ) ]
 feats <- c(feats,"perc_mito" ,"perc_rps","perc_rpl","perc_hb", "perc_protein_coding" ,"perc_lincRNA","perc_snRNA","perc_miRNA","perc_processed_pseudogene",
@@ -187,7 +188,7 @@ feats <- c(feats,"perc_mito" ,"perc_rps","perc_rpl","perc_hb", "perc_protein_cod
 feats <- feats[feats %in% colnames(DATA@meta.data)]
 
 png(filename = paste0(opt$output_path,"/QC_",i,"_ALL.png"),width = 1200*(length(unique(DATA@meta.data[,i]))/2+1),height = 700*ceiling(length(feats)/5),res = 200)
-print(VlnPlot(object = DATA, features  = feats, ncol = 5,group.by = i,pt.size = .1,assay = opt$assay))
+print(VlnPlot(object = DATA, features  = feats, ncol = 5,group.by = i,pt.size = ptsize,assay = opt$assay))
 invisible(dev.off())}
 #---------
 
@@ -281,9 +282,10 @@ print( dim(DATA@assays[[opt$assay]]@counts) )
 ### PLOT QC ###
 ###############
 cat("\nPlotting QC metrics ...\n")
+ptsize <- ifelse(ncol(DATA@assays[[opt$assay]]@counts) < 5000, 0.1, 0)  # do not show points if >5k cells
 for(i in as.character(unlist(strsplit(opt$columns_metadata,",")))){
 png(filename = paste0(opt$output_path,"/QC_",i,"_FILTERED.png"),width = 1200*(length(unique(DATA@meta.data[,i]))/2+1),height = 700*ceiling(length(feats)/5),res = 200)
-print(VlnPlot(object = DATA, features  = feats, ncol = 5,group.by = i,pt.size = .1,assay = opt$assay))
+print(VlnPlot(object = DATA, features  = feats, ncol = 5,group.by = i,pt.size = ptsize,assay = opt$assay))
 invisible(dev.off())}
 #---------
 

--- a/scripts/VDJ_analysis.R
+++ b/scripts/VDJ_analysis.R
@@ -394,7 +394,7 @@ if( !is.null( names(DATA@reductions)) ){
   cat("   Mapping clone abundance to reduced dimentions ...\n")
   for(red in names(DATA@reductions)){
     png(filename = paste0(output_path,"/",k,"_",j,"_",red,"_scale.png"),width = 900,height = 800,res = 150)
-    print( FeaturePlot(DATA,reduction = red,cols = c("grey90","navy"),features = paste0(k,"_",j,"_abundance")) )
+    print( FeaturePlot(DATA,reduction = red,cols = c("grey90","blue3","navy"), order=T, features = paste0(k,"_",j,"_abundance")) )
     dev.off()
     
     png(filename = paste0(output_path,"/",k,"_",j,"_",red,"_factor.png"),width = 1800,height = 800,res = 150)

--- a/scripts/VDJ_analysis.R
+++ b/scripts/VDJ_analysis.R
@@ -199,9 +199,13 @@ write.csv2( VDJ , paste0(opt$output_path,"/VDJ_table.csv") )
 ### Filter clonotypes without pair ###
 ######################################
 if( casefold(opt$paired_only) %in% c("true","yes") ){
-  for(i in c("TCRab_clonotype","TCRgd_clonotype","IGhl_clonotype","IGhk_clonotype")){
-    VDJ <-  VDJ[ !grepl("NA[_]|[_]NA",VDJ[,i]) | grepl("NA[_]NA",VDJ[,i]), ]
+  for(i in c("TCRab_clonotype","TCRgd_clonotype")){
+    VDJ <- VDJ[ !grepl("NA[_]|[_]NA",VDJ[,i]) | grepl("NA[_]NA",VDJ[,i]), ]
   }
+  # For IG filtering, either all chains are NA, or there is at least one IGH-IGL or IGH-IGK pair
+  i <- c("IGhl_clonotype","IGhk_clonotype")
+  VDJ <- VDJ[ ( grepl("NA[_]NA",VDJ[,i[1]]) & grepl("NA[_]NA",VDJ[,i[2]]) ) | 
+              (!grepl("NA[_]|[_]NA",VDJ[,i[1]]) | !grepl("NA[_]|[_]NA",VDJ[,i[2]]) ), ]
 }
 cat("\n The FILTERED VDJ table contains this amount of chains ...\n")
 write.csv2( VDJ , paste0(opt$output_path,"/VDJ_table_paired_only.csv") )
@@ -251,8 +255,11 @@ for(j in ls ){
 ### Computing relative abundances ###
 #####################################
 cat(" Computing relative abundances ...\n")
-    
-temp_VDJ <- VDJ[ grepl( k , VDJ$chain ), ]
+
+if( casefold(opt$paired_only) %in% c("true","yes") & grepl('clonotype', j)){
+  temp_VDJ <- VDJ[ !grepl("NA[_]|[_]NA", VDJ[, j]), ]
+} else {
+  temp_VDJ <- VDJ[ grepl( k , VDJ$chain ), ] }
 #temp_VDJ <- temp_VDJ[!duplicated(temp_VDJ$barcode),]
 temp_VDJ <- temp_VDJ[temp_VDJ$barcode %in% rownames(DATA@meta.data),]
 abund_all_cell <- sapply( unique(temp_VDJ$barcode) , function(p) {  temp_VDJ[temp_VDJ$barcode==p, j ] [1] } )


### PR DESCRIPTION
This fix revises the `VDJ_analysis.R` function to correct its detection and filtering of IGH-IGK and IGH-IGL pairs. 

Previously, if the `paired_only` option was set to `true`, it would only keep rows with *both* an IGH-IGK and IGH-IGL pair, which are quite rare. Furthermore, when retrieving the most abundant IGH-IGK or IGH-IGL pairs (for e.g., plotting), it would not differentiate between the two pair types and instead retrieve the most abundant overall.

The `VDJ_analysis.R` function will now only filter out rows that are missing *both* IGH-IGK and IGH-IGL pairs (unless all IG are missing, in the case of TCRs), and treats IGH-IGK pairs separately from IGH-IGL pairs.

In addition, the plotting of relative abundances has been updated to plot the cells in order such that those with higher clonotype abundance are plotted on top.

Finally, the `01_qc_filter.R` function was updated such that individual points (cells) are not shown on violin plots if the total cell number exceeds 5000.