### PR TITLE
Miscellaneous updates

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -32,6 +32,7 @@ dependencies:
  - r-scales=1.0
  - r-seurat=3.0.1
  - r-vegan=2.5
+ - r-venn=1.7
  - r-hdf5r=1.2.0
  - r-umap=0.2
  - leidenalg=0.7.0

--- a/scripts/00_load_data.R
+++ b/scripts/00_load_data.R
@@ -52,8 +52,13 @@ suppressMessages(suppressWarnings(library(parallel)))
 ### LOAD DATA AND SETUP Seurat.v3 OBJECT ###
 ############################################
 cat("\nLoading/ data and metadata ...\n")
-dataset_metadata <- as.data.frame(read.csv2(opt$dataset_metadata_path))
-if(ncol(dataset_metadata) == 0){dataset_metadata <- as.data.frame(read.csv(opt$dataset_metadata_path))}
+
+L <- readLines(read.csv2(opt$dataset_metadata_path), n=1)
+if (grepl(";", L)) {
+  dataset_metadata <- as.data.frame(read.csv2(opt$dataset_metadata_path))
+} else {
+  dataset_metadata <- as.data.frame(read.csv(opt$dataset_metadata_path))
+}
 print(as.character(dataset_metadata[,1]))
 
 datasets <- list.dirs(opt$input_path,recursive = F,full.names = F)

--- a/scripts/00_load_data.R
+++ b/scripts/00_load_data.R
@@ -53,7 +53,7 @@ suppressMessages(suppressWarnings(library(parallel)))
 ############################################
 cat("\nLoading/ data and metadata ...\n")
 
-L <- readLines(read.csv2(opt$dataset_metadata_path), n=1)
+L <- readLines(opt$dataset_metadata_path, n=1)
 if (grepl(";", L)) {
   dataset_metadata <- as.data.frame(read.csv2(opt$dataset_metadata_path))
 } else {

--- a/scripts/01_qc_filter.R
+++ b/scripts/01_qc_filter.R
@@ -242,8 +242,14 @@ saveRDS(DATA, file = paste0(opt$output_path,"/raw_seurat_object.rds") )
 ########################################
 if( casefold(opt$keep_genes) != "none" ){
   genes_keep <- trimws(unlist(strsplit(casefold(opt$keep_genes), ',')))
+  genes_notfound <- setdiff(genes_keep, casefold(rownames(DATA@assays[[opt$assay]]@counts)))
+  genes_keep <- rownames(DATA@assays[[opt$assay]]@counts)[casefold(rownames(DATA@assays[[opt$assay]]@counts)) %in% genes_keep]
   cat("\nThe following genes will NOT be removed from the data:\n")
   cat(genes_keep, "\n")
+  if(length(genes_notfound) > 0){
+    cat("\nWARNING: The following requested genes were NOT FOUND in the data:\n")
+    cat(genes_notfound, "\n")
+  }
 } else {
   genes_keep <- NULL
 }

--- a/scripts/01_qc_filter.R
+++ b/scripts/01_qc_filter.R
@@ -14,7 +14,9 @@ option_list = list(
   make_option(c("-r", "--remove_gene_family"),    type = "character",   metavar="character",   default='mt-',  help="Gene families to remove from the data after QC. They should start with the pattern."),
   make_option(c("-k", "--keep_genes"),            type = "character",   metavar="character",   default='none',  help ="Genes to keep in the data, separated by commas. This will override all other filtering attempts to remove these genes."),
   make_option(c("-g", "--min_gene_count"),        type = "character",   metavar="character",   default='5',  help="Minimun number of cells needed to consider a gene as expressed. Defaults to 5."),
-  make_option(c("-c", "--min_gene_per_cell"),        type = "character",   metavar="character",   default='200', help="Minimun number of genes in a cell needed to consider a cell as good quality. Defoust to 200."),
+  make_option(c("-c", "--min_gene_per_cell"),        type = "character",   metavar="character",   default='200', help="Minimun number of genes in a cell needed to consider a cell as good quality. Defaults to 200."),
+  make_option(        "--pct_mito_range",         type = "character",   metavar="character",   default='0,25', help="Range (min,max) of allowed percentage of counts attributed to mitochondrial genes. Defaults to '0,25'."),
+  make_option(        "--pct_ribo_range",         type = "character",   metavar="character",   default='0,50', help="Range (min,max) of allowed percentage of counts attributed to ribosomal (rps or rpl) genes. Defaults to '0,50'."),
   make_option(c("-a", "--assay"),                 type = "character",   metavar="character",   default='rna',   help="Assay to be used in the analysis."),
   make_option(c("-o", "--output_path"),           type = "character",   metavar="character",   default='none',  help="Output directory")
 ) 
@@ -202,10 +204,13 @@ cat("\nFiltering low quality cells ...\n")
 NF <-  DATA@meta.data [ grepl("nFeature",colnames(DATA@meta.data)) ][,1]
 NC <-  DATA@meta.data [ grepl("nCount",colnames(DATA@meta.data)) ][,1]
 
+mito_range <- as.numeric(unlist(strsplit(opt$pct_mito_range, ',')))
+ribo_range <- as.numeric(unlist(strsplit(opt$pct_ribo_range, ',')))
+
 Ts <- data.frame(
-  MitoT = between(DATA$perc_mito,0.00,25),
-  RpsT = between(DATA$perc_rps,0,50),
-  RplT = between(DATA$perc_rps,0,50),
+  MitoT = between(DATA$perc_mito, mito_range[1], mito_range[2]),
+  RpsT = between(DATA$perc_rps, ribo_range[1], ribo_range[2]),
+  RplT = between(DATA$perc_rpl, ribo_range[1], ribo_range[2]),
   nUMIT = between(NF,quantile(NF,probs = c(0.005)),quantile(NF,probs = c(0.995))),
   nCountT = between(NC,quantile(NC,probs = c(0.005)),quantile(NC,probs = c(0.995))),
   GiniT = between(DATA$gini_index,0.9,1),

--- a/scripts/01_qc_filter.R
+++ b/scripts/01_qc_filter.R
@@ -18,6 +18,7 @@ option_list = list(
   make_option(c("-j", "--normalization"),         type = "character",   metavar="character",   default='LogNormalize', help="Method to normalize the data. Options are: 'LogNormalize' (default), 'CLR','RC','Housekeeping'."),
   make_option(        "--pct_mito_range",         type = "character",   metavar="character",   default='0,25', help="Range (min,max) of allowed percentage of counts attributed to mitochondrial genes. Defaults to '0,25'."),
   make_option(        "--pct_ribo_range",         type = "character",   metavar="character",   default='0,50', help="Range (min,max) of allowed percentage of counts attributed to ribosomal (rps or rpl) genes. Defaults to '0,50'."),
+  make_option(c("-x", "--remove_cells"),          type = "character",   metavar="character",   default='none',  help="Comma-separated list of cell barcodes, or the path to a .txt or .csv file containing a list of cell barcodes that should be removed from the Seurat object after QC. If a file path is provided, the file should be formatted as a single column of barcodes with no row or column names."),  
   make_option(c("-a", "--assay"),                 type = "character",   metavar="character",   default='rna',   help="Assay to be used in the analysis."),
   make_option(c("-o", "--output_path"),           type = "character",   metavar="character",   default='none',  help="Output directory")
 ) 
@@ -221,6 +222,23 @@ dim(DATA)
 cell_use <- rownames(Ts)[ rowSums(!Ts) == 0 ]
 DATA$filtered <- (rowSums(Ts) == 0)
 #---------
+
+
+###############################
+### REMOVE ADDITIONAL CELLS ###
+###############################
+if (casefold(opt$remove_cells) != "none") {
+  cat("\nRemoving specified cells from the Seurat object\n")
+  if (endsWith(opt$remove_cells, '.csv')) {
+    excl_barcodes <- read.csv(opt$remove_cells, stringsAsFactors=F, header=F)[[1]]
+  } else if (endsWith(opt$remove_cells, '.txt')) {
+    excl_barcodes <- read.delim(opt$remove_cells, stringsAsFactors=F, header=F)[[1]]
+  } else {
+    excl_barcodes <- trimws(unlist(strsplit(opt$remove_cells, ',')))
+  }
+  cell_use <- setdiff(cell_use, excl_barcodes)
+}
+
 
 
 #######################################

--- a/scripts/01_qc_filter.R
+++ b/scripts/01_qc_filter.R
@@ -278,7 +278,7 @@ if( casefold(opt$remove_non_coding) == 'true' ){
 if(opt$remove_gene_family != "none"){
   cat("\nRemoving selected genes from the data ...\n")
   print( strsplit(opt$remove_gene_family,",")[[1]] )
-  genes_use <- rownames(DATA@assays[[opt$assay]]@counts)[!grepl(gsub(",","|",casefold(opt$remove_gene_family) ) , casefold(rownames(DATA@assays[[opt$assay]]@counts)))]
+  genes_use <- rownames(DATA@assays[[opt$assay]]@counts)[!grepl(gsub(",","|", sub('mito','mt-',casefold(opt$remove_gene_family)) ), casefold(rownames(DATA@assays[[opt$assay]]@counts)))]
   genes_use <- union(genes_use, genes_keep)
   DATA@assays[[opt$assay]]@counts <- DATA@assays[[opt$assay]]@counts[genes_use,]
 }

--- a/scripts/01_qc_filter.R
+++ b/scripts/01_qc_filter.R
@@ -14,7 +14,7 @@ option_list = list(
   make_option(c("-r", "--remove_gene_family"),    type = "character",   metavar="character",   default='mt-',  help="Gene families to remove from the data after QC. They should start with the pattern."),
   make_option(c("-k", "--keep_genes"),            type = "character",   metavar="character",   default='none',  help ="Genes to keep in the data, separated by commas. This will override all other filtering attempts to remove these genes."),
   make_option(c("-g", "--min_gene_count"),        type = "character",   metavar="character",   default='5',  help="Minimun number of cells needed to consider a gene as expressed. Defaults to 5."),
-  make_option(c("-c", "--min_gene_per_cell"),        type = "character",   metavar="character",   default='200', help="Minimun number of genes in a cell needed to consider a cell as good quality. Defaults to 200."),
+  make_option(c("-c", "--min_gene_per_cell"),     type = "character",   metavar="character",   default='200', help="Minimun number of genes in a cell needed to consider a cell as good quality. Defaults to 200."),
   make_option(c("-j", "--normalization"),         type = "character",   metavar="character",   default='LogNormalize', help="Method to normalize the data. Options are: 'LogNormalize' (default), 'CLR','RC','Housekeeping'."),
   make_option(        "--pct_mito_range",         type = "character",   metavar="character",   default='0,25', help="Range (min,max) of allowed percentage of counts attributed to mitochondrial genes. Defaults to '0,25'."),
   make_option(        "--pct_ribo_range",         type = "character",   metavar="character",   default='0,50', help="Range (min,max) of allowed percentage of counts attributed to ribosomal (rps or rpl) genes. Defaults to '0,50'."),

--- a/scripts/02_integrate.R
+++ b/scripts/02_integrate.R
@@ -132,7 +132,7 @@ if ((length(integration_method) >= 2) & (casefold(integration_method[1]) == "com
   mod0 <- model.matrix(~1, data=as.data.frame(DATA@meta.data))
   
   #Transforming counts to log
-  logdata <- log2(as.matrix(DATA@assays[[opt$assay]]@data)[,rownames(DATA@meta.data)]+1)
+  logdata <- log2(as.matrix(DATA@assays[[opt$assay]]@counts)[,rownames(DATA@meta.data)]+1)
   sum(rowSums(logdata) == 0)
   logdata <- logdata[rowSums(logdata) != 0,]
   

--- a/scripts/03_dr_and_cluster.R
+++ b/scripts/03_dr_and_cluster.R
@@ -474,8 +474,8 @@ if( 'kmeans' %in% casefold(unlist(strsplit(opt$cluster_method,split = ","))) ){
   
   mincells <- 15
   ideal <- round(ncol(DATA) / mincells)
-  clcl<- kmeans(DATA@reductions$umap10@cell.embeddings,centers = ncol(DATA)/10,iter.max = 50)
-  DATA <- AddMetaData(DATA,metadata = setNames(clcl$cluster,colnames(DATA)), paste0("kmeans_",k))
+  clcl<- kmeans(DATA@reductions$umap10@cell.embeddings,centers = ideal,iter.max = 50)
+  DATA <- AddMetaData(DATA,metadata = setNames(clcl$cluster,colnames(DATA)), paste0("kmeans_",ideal))
 
   temp <- rowsum(DATA@reductions$umap10@cell.embeddings,clcl$cluster) / as.vector(table(clcl$cluster))
   cors <- cor(t(temp))
@@ -525,7 +525,7 @@ if( 'hdbscan' %in% casefold(unlist(strsplit(opt$cluster_method,split = ","))) ){
   
   for(k in seq(5,100,by=2)){
     cat(k,"\t")
-    clusters <- hdbscan(DATA@reductions$umap@cell.embeddings, minPts = k)
+    clusters <- hdbscan(DATA@reductions$umap10@cell.embeddings, minPts = k)
     names(clusters$cluster) <- rownames(DATA@meta.data)
     DATA <- AddMetaData(object = DATA, metadata = clusters$cluster, col.name = paste0("hdbscan_",k))
   }

--- a/scripts/03_dr_and_cluster.R
+++ b/scripts/03_dr_and_cluster.R
@@ -15,6 +15,7 @@ option_list = list(
   make_option(c("-m", "--cluster_method"),        type = "character",   metavar="character",   default='leiden', help="The clustering method and cluster to select for analysis. Current methods are 'hc','louvain','dbscan','hdbscan','flowpeaks','kmeans','leiden'. If no input is suplied, all methods will be run."),
   make_option(c("-n", "--k_nearest_neighbour"),   type = "character",   metavar="character",   default='30', help="The number of nearest neighbours for graph construction."),
   make_option(c("-d", "--dim_reduct_use"),        type = "character",   metavar="character",   default='umap',  help="Which dimensionality reduction method to be run on top of `pre_dim_reduct`: UMAP (default) or tSNE. If both, then specify them comma-separated'UMAP,tSNE'."),
+  make_option(c("-q", "--dim_reduct_params"),     type = "character",   metavar="character",   default='default',  help="Dimensionality reduction parameters to pass to the dimensionality reduction algorithm. Separate methods by semicolons and parameters by commas: 'METHOD1,param1=value1,param2=value2;METHOD2,param1=value1'. For example: 'UMAP, n.neighbors=10, min.dist=0.1; tSNE, perplexity=30, theta=0.1'. Currently only adjusts tSNE and UMAP parameters."),
   make_option(c("-k", "--pre_dim_reduct"),        type = "character",   metavar="character",   default='pca',  help="Which dimensionality reduction method to be run, PCA is run by default. If you run 'MNN', you can use it here."),
   make_option(c("-a", "--assay"),                 type = "character",   metavar="character",   default='RNA',  help="Assay to be used in the analysis."),
   make_option(c("-o", "--output_path"),           type = "character",   metavar="character",   default='none',  help="Output directory")
@@ -158,6 +159,15 @@ invisible(dev.off())
 
 
 
+#################################################
+### Parse dimensionality reduction parameters ###
+#################################################
+param_set <- paste0(sub(",", "=list(", casefold(unlist(strsplit(opt$dim_reduct_params, ";")))), ")", collapse=",")
+dim_reduct_params <- eval(parse(text=paste0("list(", param_set, ")")))
+#---------
+
+
+
 ####################
 ### Running tSNE ###
 ####################
@@ -170,8 +180,23 @@ if( "tsne" %in% casefold(unlist(strsplit(opt$dim_reduct_use,",")))){
     DATA@reductions[["tsne"]] <- CreateDimReducObject(embeddings = as.matrix(read.csv2(paste0(opt$output_path,"/tsne_plots/tSNE_coordinates.csv"),row.names = 1)),key = "tSNE_",assay = opt$assay)
   } else { cat("\nPre-computed tSNE NOT found. Computing tSNE ...\n")
     
+    tsne_params <- list(perplexity = 30,  # set default parameters
+                        max_iter = 2000,
+                        theta = 0.1,
+                        eta = 2000,
+                        exaggeration_factor = 12,
+                        dims.use = 1:top_PCs,
+                        verbose = T,
+                        num_threads = 0)
+    # overwrite defaults with specified parameters
+    if("tsne" %in% names(dim_reduct_params)){ tsne_params <- modifyList(tsne_params, dim_reduct_params$tsne) }
+    
     ttt <- Sys.time()
-    DATA <- RunTSNE(object = DATA, reduction = casefold(opt$pre_dim_reduct), perplexity=30, max_iter=2000,theta=0.1,eta=2000,exaggeration_factor=12,dims.use = 1:top_PCs,verbose = T,num_threads=0)
+    # long command because "do.call()" is extremely slow with large objects
+    DATA <- RunTSNE(object=DATA, reduction=casefold(opt$pre_dim_reduct), 
+                    perplexity=tsne_params$perplexity, max_iter=tsne_params$max_iter, theta=tsne_params$theta,
+                    eta=tsne_params$eta, exaggeration_factor=tsne_params$exaggeration_factor, dims.use=tsne_params$dims.use,
+                    verbose=tsne_params$verbose, num_threads=tsne_params$num_threads)
     cat("multicore tSNE ran in ",difftime(Sys.time(), ttt, units='mins'))
     write.csv2(DATA@reductions$tsne@cell.embeddings, paste0(opt$output_path,"/tsne_plots/tSNE_coordinates.csv"))}
 }
@@ -193,14 +218,49 @@ if( "umap" %in% casefold(unlist(strsplit(opt$dim_reduct_use,",")))){
 
   } else { cat("\nPre-computed UMAP NOT found. Computing UMAP ...\n")
     
+    umap_params <- list(dims = 1:top_PCs,
+                        n.neighbors = 10,
+                        spread = 0.3,
+                        repulsion.strength = 1,
+                        learning.rate = 1,
+                        min.dist= 0.001,
+                        verbose = T,
+                        num_threads=0,
+                        n.epochs = 200,
+                        metric = "euclidean",
+                        seed.use = 42)
+    # overwrite defaults with specified parameters
+    if("umap" %in% names(dim_reduct_params)){ umap_params <- modifyList(umap_params, dim_reduct_params$umap) }
+    
     ttt <- Sys.time()
-    DATA <- RunUMAP(object = DATA, reduction = casefold(opt$pre_dim_reduct), dims = 1:top_PCs, n.components = 2, n.neighbors = 10, spread = .3,
-                    repulsion.strength = 1, min.dist= .001, verbose = T,num_threads=0,n.epochs = 200,metric = "euclidean",seed.use = 42)
+    # long command because "do.call()" is extremely slow with large objects
+    DATA <- RunUMAP(object=DATA, reduction=casefold(opt$pre_dim_reduct), n.components=2,
+                    dims=umap_params$dims, n.neighbors=umap_params$n.neighbors, learning.rate=umap_params$learning.rate, spread=umap_params$spread,
+                    repulsion.strength=umap_params$repulsion.strength, min.dist=umap_params$min.dist, verbose=umap_params$verbose,
+                    num_threads=umap_params$num_threads, n.epochs=umap_params$n.epochs, metric=umap_params$metric, seed.use=umap_params$seed.use)
     cat("UMAP_2dimensions ran in ",difftime(Sys.time(), ttt, units='mins'),"\n")
     invisible(gc())
-    ttt <- Sys.time()
     
-    DATA <- RunUMAP(object = DATA, dims = 1:top_PCs, n.components = 10, n.neighbors = 15, spread = 1, min.dist= .1,metric = "euclidean",verbose = T,num_threads=0,learning.rate = .2,n.epochs = 200,reduction.name = "umap10",reduction.key = "umap10_")
+    umap10_params <- list(dims = 1:top_PCs,
+                          n.neighbors = 15,
+                          spread = 1,
+                          repulsion.strength = 1,
+                          learning.rate = 0.2,
+                          min.dist= 0.1,
+                          verbose = T,
+                          num_threads=0,
+                          n.epochs = 200,
+                          metric = "euclidean",
+                          seed.use = 42)
+    # overwrite defaults with specified parameters
+    if("umap10" %in% names(dim_reduct_params)){ umap10_params <- modifyList(umap10_params, dim_reduct_params$umap10) }
+    
+    ttt <- Sys.time()
+    # long command because "do.call()" is extremely slow with large objects
+    DATA <- RunUMAP(object=DATA, n.components=10, reduction.name="umap10", reduction.key="umap10_",
+                    dims=umap10_params$dims, n.neighbors=umap10_params$n.neighbors, spread=umap10_params$spread, repulsion.strength=umap10_params$repulsion.strength,
+                    learning.rate=umap10_params$learning.rate, min.dist= umap10_params$min.dist, verbose=umap10_params$verbose, num_threads=umap10_params$num_threads,
+                    n.epochs=umap10_params$n.epochs, metric=umap10_params$metric, seed.use=umap10_params$seed.use)
     cat("UMAP_10dimensions ran in ",difftime(Sys.time(), ttt, units='mins'))
     invisible(gc())
     write.csv2(DATA@reductions$umap@cell.embeddings, paste0(opt$output_path,"/umap_plots/UMAP_coordinates.csv"))

--- a/scripts/03_dr_and_cluster.R
+++ b/scripts/03_dr_and_cluster.R
@@ -257,7 +257,7 @@ if( "umap" %in% casefold(unlist(strsplit(opt$dim_reduct_use,",")))){
     
     ttt <- Sys.time()
     # long command because "do.call()" is extremely slow with large objects
-    DATA <- RunUMAP(object=DATA, n.components=10, reduction.name="umap10", reduction.key="umap10_",
+    DATA <- RunUMAP(object=DATA, reduction=casefold(opt$pre_dim_reduct), n.components=10, reduction.name="umap10", reduction.key="umap10_",
                     dims=umap10_params$dims, n.neighbors=umap10_params$n.neighbors, spread=umap10_params$spread, repulsion.strength=umap10_params$repulsion.strength,
                     learning.rate=umap10_params$learning.rate, min.dist= umap10_params$min.dist, verbose=umap10_params$verbose, num_threads=umap10_params$num_threads,
                     n.epochs=umap10_params$n.epochs, metric=umap10_params$metric, seed.use=umap10_params$seed.use)

--- a/scripts/03_dr_and_cluster.R
+++ b/scripts/03_dr_and_cluster.R
@@ -228,6 +228,7 @@ if( "umap" %in% casefold(unlist(strsplit(opt$dim_reduct_use,",")))){
                         num_threads=0,
                         n.epochs = 200,
                         metric = "euclidean",
+                        negative.sample.rate = 5L,
                         seed.use = 42)
     # overwrite defaults with specified parameters
     if("umap" %in% names(dim_reduct_params)){ umap_params <- modifyList(umap_params, dim_reduct_params$umap) }
@@ -237,7 +238,8 @@ if( "umap" %in% casefold(unlist(strsplit(opt$dim_reduct_use,",")))){
     DATA <- RunUMAP(object=DATA, reduction=casefold(opt$pre_dim_reduct), n.components=2,
                     dims=umap_params$dims, n.neighbors=umap_params$n.neighbors, learning.rate=umap_params$learning.rate, spread=umap_params$spread,
                     repulsion.strength=umap_params$repulsion.strength, min.dist=umap_params$min.dist, verbose=umap_params$verbose,
-                    num_threads=umap_params$num_threads, n.epochs=umap_params$n.epochs, metric=umap_params$metric, seed.use=umap_params$seed.use)
+                    num_threads=umap_params$num_threads, n.epochs=umap_params$n.epochs, metric=umap_params$metric, seed.use=umap_params$seed.use,
+                    negative.sample.rate=umap_params$negative.sample.rate)
     cat("UMAP_2dimensions ran in ",difftime(Sys.time(), ttt, units='mins'),"\n")
     invisible(gc())
     
@@ -251,6 +253,7 @@ if( "umap" %in% casefold(unlist(strsplit(opt$dim_reduct_use,",")))){
                           num_threads=0,
                           n.epochs = 200,
                           metric = "euclidean",
+                          negative.sample.rate = 5L,
                           seed.use = 42)
     # overwrite defaults with specified parameters
     if("umap10" %in% names(dim_reduct_params)){ umap10_params <- modifyList(umap10_params, dim_reduct_params$umap10) }
@@ -260,7 +263,7 @@ if( "umap" %in% casefold(unlist(strsplit(opt$dim_reduct_use,",")))){
     DATA <- RunUMAP(object=DATA, reduction=casefold(opt$pre_dim_reduct), n.components=10, reduction.name="umap10", reduction.key="umap10_",
                     dims=umap10_params$dims, n.neighbors=umap10_params$n.neighbors, spread=umap10_params$spread, repulsion.strength=umap10_params$repulsion.strength,
                     learning.rate=umap10_params$learning.rate, min.dist= umap10_params$min.dist, verbose=umap10_params$verbose, num_threads=umap10_params$num_threads,
-                    n.epochs=umap10_params$n.epochs, metric=umap10_params$metric, seed.use=umap10_params$seed.use)
+                    n.epochs=umap10_params$n.epochs, metric=umap10_params$metric, seed.use=umap10_params$seed.use, negative.sample.rate=umap10_params$negative.sample.rate)
     cat("UMAP_10dimensions ran in ",difftime(Sys.time(), ttt, units='mins'))
     invisible(gc())
     write.csv2(DATA@reductions$umap@cell.embeddings, paste0(opt$output_path,"/umap_plots/UMAP_coordinates.csv"))

--- a/scripts/03_dr_and_cluster.R
+++ b/scripts/03_dr_and_cluster.R
@@ -322,7 +322,7 @@ if( "ica" %in% casefold(unlist(strsplit(opt$dim_reduct_use,",")))){
 ###################
 cat("\n### Running SNN on ",casefold(opt$pre_dim_reduct)," ###\n")
 DATA <- FindNeighbors(DATA, assay = opt$assay, graph.name="SNN", prune.SNN = .2,k.param = as.numeric(opt$k_nearest_neighbour),force.recalc = T,reduction = casefold(opt$pre_dim_reduct), dims = 1:top_PCs )
-g <- graph_from_adjacency_matrix(as.matrix(DATA@graphs$SNN),weighted = T,diag=F)
+g <- graph_from_adjacency_matrix(DATA@graphs$SNN,weighted = T,diag=F)
 g <- simplify(g)
 saveRDS(DATA@graphs$SNN, file = paste0(opt$output_path,"/SNN_Graph.rds") )
 

--- a/scripts/03_dr_and_cluster.R
+++ b/scripts/03_dr_and_cluster.R
@@ -473,7 +473,7 @@ rm(temp2); invisible(gc())
 ### SAVING RAW Seurat.v3 OBJECT ###
 ###################################
 cat("\n### Saving the Seurat object ###\n")
-saveRDS(DATA, file = paste0(opt$output_path,"/Seurat_object.rds") )
+saveRDS(DATA, file = paste0(opt$output_path,"/seurat_object.rds") )
 write.csv2(DATA@meta.data,paste0(opt$output_path,"/Metadata_with_clustering.csv"),row.names = T)
 #---------
 

--- a/scripts/VDJ_analysis.R
+++ b/scripts/VDJ_analysis.R
@@ -43,6 +43,16 @@ initial.options <- commandArgs(trailingOnly = FALSE)
 script_path <- dirname(sub("--file=","",initial.options[grep("--file=",initial.options)]))
 source( paste0(script_path,"/inst_packages.R") )
 pkgs <- c("rafalib","dplyr","RColorBrewer","scales","igraph","pheatmap","Seurat","venn")
+
+suppressMessages(suppressWarnings(library(rafalib)))
+suppressMessages(suppressWarnings(library(dplyr)))
+suppressMessages(suppressWarnings(library(RColorBrewer)))
+suppressMessages(suppressWarnings(library(scales)))
+suppressMessages(suppressWarnings(library(igraph)))
+suppressMessages(suppressWarnings(library(pheatmap)))
+suppressMessages(suppressWarnings(library(Seurat)))
+suppressMessages(suppressWarnings(library(venn)))
+
 inst_packages(pkgs)
 
 
@@ -80,7 +90,7 @@ VDJ <- data.frame()
 for(i in datasets){
   file <- list.files(paste0(opt$VDJ_annotation_path,"/",i))
   #read multiple files here
-  file <- file[grep("filtered_contig_annotations.csv",file)] [1]
+  file <- file[grep("filtered_contig_annotations.*[.]csv",file)] [1]
   temp <- read.csv(paste0(opt$VDJ_annotation_path,"/",i,"/",file) )
   temp$barcode <- paste0(sub("-.*","",temp$barcode),"_",i)
   temp$dataset <- i
@@ -447,7 +457,7 @@ if( !is.null( names(DATA@reductions)) ){
 ### SAVING RAW Seurat.v3 OBJECT ###
 ###################################
 cat("\nSaving the RAW Seurat object ...\n")
-saveRDS(DATA, file = paste0(opt$output_path,"/Seurat_object_TCR.rds") )
+saveRDS(DATA, file = paste0(opt$output_path,"/seurat_object_TCR.rds") )
 #---------
 
 

--- a/scripts/VDJ_analysis.R
+++ b/scripts/VDJ_analysis.R
@@ -56,7 +56,7 @@ suppressMessages(suppressWarnings(library(pheatmap)))
 suppressMessages(suppressWarnings(library(Seurat)))
 suppressMessages(suppressWarnings(library(venn)))
 
-inst_packages(pkgs)
+# inst_packages(pkgs)
 
 
 pal <- scales::hue_pal()

--- a/scripts/cell_type_prediction.R
+++ b/scripts/cell_type_prediction.R
@@ -75,7 +75,12 @@ for(i in sub(".*/","",sub(".csv","",marker_lists)) ){
   if(!dir.exists(PATH)){dir.create(PATH,recursive = T)}
   
   cat("\nProcessing list '", sub(".*/","",i) ,"' ...\n")
-  cellIDs <- read.csv2(marker_lists[grep(i,marker_lists)],header =T)
+  fullname <- marker_lists[grep(paste0('/',i,'.csv'),marker_lists)]
+  if (grepl(";", readLines(fullname, n=1))) {
+    cellIDs <- read.csv2(fullname,header=T)
+  } else {
+    cellIDs <- read.csv(fullname,header=T)
+  }
   cellIDs <- as.list(as.data.frame(cellIDs))
   cellIDs <- lapply(cellIDs, function(x) casefold( as.character(x[x!=""]) ) )
   #cellIDs <- lapply(cellIDs, function(x) x[1:min(10,length(x))] )

--- a/scripts/cell_type_prediction.R
+++ b/scripts/cell_type_prediction.R
@@ -119,15 +119,13 @@ cat("\nComputing correlations ...\n")
 cors <- apply(DATA@assays[[opt$assay]]@data[ sel ,],2,function(x) cor(x , cell_ident) )
 cors[is.na(cors)] <- -1
 rownames(cors) <- colnames(cell_ident)
-cors2 <- t(t(cors) / apply(cors,2,max))
-cors2[1:nrow(cors2),1:20]
-print(cors2[,1:5])
+print(cors[,1:5])
 gc()
 try(write.csv2(cors,paste0(opt$output_path,"/",i,"/cell_pred_correlation_",i,".csv"),row.names = T))
 
 cat("\nPredicting cell types ...\n")
-pred <- unlist( apply(cors2,2,function(x) colnames(cell_ident) [which.max(x)]) )
-my_nas <- colnames(cors2)[! colnames(cors2) %in% names(pred)]
+pred <- unlist( apply(cors,2,function(x) colnames(cell_ident) [which.max(x)]) )
+my_nas <- colnames(cors)[! colnames(cors) %in% names(pred)]
 pred <- c(pred , setNames(rep(NA,length(my_nas)),my_nas))
 
 cat("\nPlotting ...\n")

--- a/scripts/cell_type_prediction.R
+++ b/scripts/cell_type_prediction.R
@@ -42,7 +42,13 @@ initial.options <- commandArgs(trailingOnly = FALSE)
 script_path <- dirname(sub("--file=","",initial.options[grep("--file=",initial.options)]))
 source( paste0(script_path,"/inst_packages.R") )
 pkgs <- c("Seurat","scales","fields","data.table")
-inst_packages(pkgs)
+
+suppressMessages(suppressWarnings(library(Seurat)))
+suppressMessages(suppressWarnings(library(scales)))
+suppressMessages(suppressWarnings(library(fields)))
+suppressMessages(suppressWarnings(library(data.table)))
+
+# inst_packages(pkgs)
 #---------
 
 

--- a/scripts/compute_hvgs.R
+++ b/scripts/compute_hvgs.R
@@ -1,6 +1,7 @@
 #!/usr/bin/env Rscript
 
-compute_hvgs <- function(object,VAR_choice,output_path,assay="rna"){
+compute_hvgs <- function(object,VAR_choice,output_path,assay="rna", nSeurat=2000){
+  print(VAR_choice)
   if(!dir.exists(output_path)){dir.create(output_path,recursive = T)}
   if(casefold(VAR_choice[1]) == "no"){
     #Skip running variable gene selection and use all
@@ -20,7 +21,7 @@ compute_hvgs <- function(object,VAR_choice,output_path,assay="rna"){
 
 
     #Defining the variable genes based on the mean gene expression abothe the 5% quantile and the dispersion above 2.
-    object <- FindVariableFeatures(object = object,nfeatures = 3000)
+    object <- FindVariableFeatures(object = object,nfeatures = nSeurat)
     m <- max(quantile(object@assays[[assay]]@meta.features$vst.mean,probs = c(.025)) , 0.01)
 
     object@assays[[assay]]@var.features <- object@assays[[assay]]@var.features[object@assays[[assay]]@var.features %in% perc]
@@ -47,6 +48,9 @@ compute_hvgs <- function(object,VAR_choice,output_path,assay="rna"){
     ########################################################
     cat("\nCalculating highly variable genes with Scran ...\n")
 
+    print(assay)
+    print(VAR_choice)
+
     if( (length(VAR_choice)==3) & (VAR_choice[3] %in% colnames(object@meta.data)) ){
       cat("\nBlocking factor detected ...\n")
       blk <- object@meta.data[,VAR_choice[3]]
@@ -54,6 +58,7 @@ compute_hvgs <- function(object,VAR_choice,output_path,assay="rna"){
       fit$vars <- apply(fit$vars,1, function(x) {prod(x)^(1/length(x))} )
       fit$means <- apply(fit$means,1, function(x) {prod(x)^(1/length(x))} )
     } else { fit <- trendVar(object@assays[[assay]]@data,loess.args=list(span=0.05)) }
+    cat("Trendvar done\n")
 
     hvgs <- decomposeVar(object@assays[[assay]]@data, fit)
     hvgs <- as.data.frame(hvgs[order(hvgs$bio, decreasing=TRUE),])

--- a/scripts/compute_hvgs.R
+++ b/scripts/compute_hvgs.R
@@ -1,6 +1,6 @@
 #!/usr/bin/env Rscript
 
-compute_hvgs <- function(object,VAR_choice,output_path,assay="rna", nSeurat=2000){
+compute_hvgs <- function(object,VAR_choice,output_path,assay="rna", nSeurat=3000){
   print(VAR_choice)
   if(!dir.exists(output_path)){dir.create(output_path,recursive = T)}
   if(casefold(VAR_choice[1]) == "no"){

--- a/support_files/cell_markers/main_cell_types.csv
+++ b/support_files/cell_markers/main_cell_types.csv
@@ -1,6 +1,6 @@
-﻿T_cell;B_cell;NK_cell;Neutrophil;RBC;Fibroblast;Endothelial;Myocyte;Adipocyte;Epithelial;Macrophage;Platelet;DC;FCGR3A_mono;CD14_mono
+T_cell;B_cell;NK_cell;Neutrophil;RBC;Fibroblast;Endothelial;Myocyte;Adipocyte;Epithelial;Macrophage;Platelet;DC;FCGR3A_mono;CD14_mono
 Cd3g;Cd79a;Nkg7;S100a8;Hbb-bt;Col11a1;Tmem100;Myod1;Fabp7;Krt5;Lyz2;Ppbp;FCER1A;FCGR3A;CD14
-Thy1;CD74;Nrc1;S100a9;Alas2;Col1a1;Egfl7;Des;Plp1;Krt14;Ms4a6d;gp9;Clec10A;MS4A7;Lyz
+Thy1;CD74;Ncr1;S100a9;Alas2;Col1a1;Egfl7;Des;Plp1;Krt14;Ms4a6d;gp9;Clec10A;MS4A7;Lyz
 Cd3e;Ebf1;Gzmb;Retnlg;Snca;Col1a2;Ramp2;Actc1;Sox10;Perp;Ctss;cd9;CST3;;
 Cd3d;Ms4a1;Gzma;Wfdc17;Hba-a2;Gsn;Cldn5;Tnnt1;Moxd1;Sfn;;clu;;;
 ;Cd79b;Klre;G0s2;Hba-a1;Fbln2;Epas1;Myog;Phactr1;;;;;;


### PR DESCRIPTION
## Miscellaneous updates
Note that none of these changes should affect backward compatibility or default settings. Most changes involve extensions of functionality and/or increased flexibility of parameter adjustment, or minor bug fixes.

### Environment file
The `environment.yml` file was updated by adding the `r-venn` package (required by `VDJ_analysis.R`).

### 00_load_data.R
- Updated the code used to detect the format of the metadata.csv file (comma or semicolon separated). The previous code caused an error if the csv was comma-separated.
- New input allows exclusion of specific cells by providing a list or file containing cell barcodes to exclude.

### 01_qc_filter.R
- Added new input parameters:
    - `keep_genes` - A comma-separated list of gene names (case-insensitive) that should be kept in the data (override filtering)
    - `pct_mito_range` - min, max value of mitochondrial percentage allowed in each cell
    - `pct_ribo_range`  - min, max value of ribosomal (rps, rpl) percentage allowed in each cell
    - `remove_cells` - List or file of cell barcodes that should be removed from the data
- Fixed a bug where mitochondral (`mt-`) genes were not removed if `mito` was specified in the `remove_gene_family` input.

### 02_integrate.R
- Fixed log-transformation in COMBAT section to use the `counts` field instead of the already log-transformed `data` field, to avoid use of log(log(counts)).

### 03_dr_and_cluster.R
- Fixed capitalization of the output Seurat object to be consistent with other functions.
- Added a new input option `dim_reduct_params`, which allows passing of parameter values to dimensionality reduction algorithms (such as tSNE, UMAP).
    - Input is formatted as `"Method1, param1=val1, param2=val2; Method2, param1=val1"`
    - For example: `"umap, n.neighbors=10, min.dist=0.1; tsne, perplexity=30, theta=0.1"`
- Fixed the UMAP10 call to use the reduction specified by the `pre_dim_reduct` parameter. Previously it was unspecified, so the default reduction (PCA) was always used.
- hdbscan now uses UMAP10 instead of UMAP2 for clustering
- Eliminated an unnecessary conversion of the sparse SNN to a full matrix, which caused errors when working with large datasets (approx. >50k cells)

### VDJ_analysis.R
- Allowed for more flexible naming of the `filtered_contig_annotations.csv` files.

### cell_type_prediction.R
- Implemented new bar plot showing the predicted cell type composition of each cluster.
- Added compatibility for reading comma-separated `.csv` files.
- Removed a step involving scaling of the correlation coefficients by the max value (line 116), since this does not impact later calculation steps, but risks sign changes if the max correlation value is negative.

### compute_hvgs.R
- Incorporated changes from single cell hackathon; specifically, a new input `nSeurat` allows specification of the number of features (`nfeatures`) to request when calling the `FindVariableFeatures` Seurat function.

### main_cell_types.csv
- Fixed typo: "Nrc1" gene should be "Ncr1"
